### PR TITLE
Wraps error in string to get message

### DIFF
--- a/django_states/machine.py
+++ b/django_states/machine.py
@@ -248,7 +248,7 @@ class StateMachine(six.with_metaclass(StateMachineMeta, object)):
                         get_STATE_info().test_transition(transition_name,
                                                        request.user)
                     except TransitionException as e:
-                        modeladmin.message_user(request, 'ERROR: %s on: %s' % (e.message, six.text_type(o)),
+                        modeladmin.message_user(request, 'ERROR: %s on: %s' % (str(e), six.text_type(o)),
                                                 level=messages.ERROR)
                         return
 


### PR DESCRIPTION
This branch is branched from the version we're currently using in webserver.  It fixes up a small bug with wrapping the error in a string instead of calling e.message.  We don't want to merge this branch in, just pull it into webserver